### PR TITLE
Allow passing command into container definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Creates a scheduled Fargate Task in AWS
 ## Usage
 ```hcl
 module "test_scheduled_task" {
-  source = "github.com/byu-oit/terraform-aws-scheduled-fargate?ref=v1.0.0"
+  source = "github.com/byu-oit/terraform-aws-scheduled-fargate?ref=v2.0.0"
 
   app_name            = "test-scheduled-fargate-dev"
   schedule_expression = "rate(5 minutes)"

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ module "test_scheduled_task" {
   primary_container_definition = {
     name                  = "test"
     image                 = "hello-world"
+    command               = null
     environment_variables = {}
     secrets               = {}
     efs_volume_mounts     = null
@@ -52,6 +53,7 @@ module "test_scheduled_task" {
 Object with following attributes to define the docker container(s) your fargate needs to run.
 * **`name`** - (Required) container name (referenced in CloudWatch logs, and possibly by other containers)
 * **`image`** - (Required) the ecr_image_url with the tag like: `<acct_num>.dkr.ecr.us-west-2.amazonaws.com/myapp:dev` or the image URL from dockerHub or some other docker registry
+* **`command`** - (Required) the [command](https://docs.docker.com/engine/reference/run/#cmd-default-command-or-options) to run the docker container with. Can set to `null` to use the default container command.
 * **`environment_variables`** - (Required) a map of environment variables to pass to the docker container
 * **`secrets`** - (Required) a map of secrets from the parameter store to be assigned to env variables
 * **`efs_volume_mounts`** - (Required) a list of efs_volume_mount [objects](#efs_volume_mount) to be mounted into the container.

--- a/examples/ci/ci.tf
+++ b/examples/ci/ci.tf
@@ -19,6 +19,7 @@ module "scheduled_fargate" {
   primary_container_definition = {
     name                  = "test"
     image                 = "hello-world"
+    command               = null
     environment_variables = {}
     secrets               = {}
     efs_volume_mounts     = null

--- a/examples/ci/ci.tf
+++ b/examples/ci/ci.tf
@@ -19,7 +19,7 @@ module "scheduled_fargate" {
   primary_container_definition = {
     name                  = "test"
     image                 = "hello-world"
-    command               = null
+    command               = ["echo", "testing"]
     environment_variables = {}
     secrets               = {}
     efs_volume_mounts     = null

--- a/examples/ci/ci.tf
+++ b/examples/ci/ci.tf
@@ -19,7 +19,7 @@ module "scheduled_fargate" {
   primary_container_definition = {
     name                  = "test"
     image                 = "hello-world"
-    command               = ["echo", "testing"]
+    command               = null
     environment_variables = {}
     secrets               = {}
     efs_volume_mounts     = null

--- a/examples/complex/complex-example.tf
+++ b/examples/complex/complex-example.tf
@@ -42,8 +42,9 @@ module "scheduled_fargate" {
   ecs_cluster_name    = aws_ecr_repository.repo.name
   schedule_expression = "rate(5 minutes)"
   primary_container_definition = {
-    name  = "test-dynamo"
-    image = "${aws_ecr_repository.repo.repository_url}:${var.image_tag}"
+    name    = "test-dynamo"
+    image   = "${aws_ecr_repository.repo.repository_url}:${var.image_tag}"
+    command = null
     environment_variables = {
       DYNAMO_TABLE_NAME = aws_dynamodb_table.my_dynamo_table.name
     }

--- a/examples/complex/complex-example.tf
+++ b/examples/complex/complex-example.tf
@@ -35,7 +35,7 @@ output "repo_url" {
 
 // Scheduled fargate
 module "scheduled_fargate" {
-  //  source = "github.com/byu-oit/terraform-aws-scheduled-fargate?ref=v.1.0.0"
+  //  source = "github.com/byu-oit/terraform-aws-scheduled-fargate?ref=v2.0.0"
   source = "../../" # for local testing during module development
 
   app_name            = local.name

--- a/examples/simple/simple-example.tf
+++ b/examples/simple/simple-example.tf
@@ -16,6 +16,7 @@ module "scheduled_fargate" {
   primary_container_definition = {
     name                  = "test"
     image                 = "hello-world"
+    command               = null
     environment_variables = {}
     secrets               = {}
     efs_volume_mounts     = null

--- a/examples/simple/simple-example.tf
+++ b/examples/simple/simple-example.tf
@@ -8,7 +8,7 @@ module "acs" {
 }
 
 module "scheduled_fargate" {
-  //  source = "github.com/byu-oit/terraform-aws-scheduled-fargate?ref=v.1.0.0"
+  //  source = "github.com/byu-oit/terraform-aws-scheduled-fargate?ref=v2.0.0"
   source = "../../" # for local testing during module development
 
   app_name            = "scheduled-fargate-simple-example-dev"

--- a/main.tf
+++ b/main.tf
@@ -33,6 +33,7 @@ locals {
     for def in local.definitions : {
       name       = def.name
       image      = def.image
+      command    = def.command
       essential  = true
       privileged = false
       logConfiguration = {

--- a/variables.tf
+++ b/variables.tf
@@ -13,8 +13,9 @@ variable "schedule_expression" {
 }
 variable "primary_container_definition" {
   type = object({
-    name  = string
-    image = string
+    name    = string
+    image   = string
+    command = string
     //    ports                 = list(number)
     environment_variables = map(string)
     secrets               = map(string)

--- a/variables.tf
+++ b/variables.tf
@@ -15,7 +15,7 @@ variable "primary_container_definition" {
   type = object({
     name    = string
     image   = string
-    command = string
+    command = list(string)
     //    ports                 = list(number)
     environment_variables = map(string)
     secrets               = map(string)


### PR DESCRIPTION
@byujol has a use-case where he'd like to use a single docker image in multiple ways, which docker supports by passing in a [command](https://docs.docker.com/engine/reference/run/#cmd-default-command-or-options).

I'd normally call this a minor-version update, but since we can't have default values for attributes on an object like `primary_container_definition` (until [this](https://www.terraform.io/docs/configuration/types.html#experimental-optional-object-type-attributes) is no longer experimental), users would need to explicitly pass in `command = null`. Are we calling that a major-version update?